### PR TITLE
Remove unnessesary copy for OpenMP offload

### DIFF
--- a/openmp-offload/simulation.c
+++ b/openmp-offload/simulation.c
@@ -33,8 +33,10 @@ void run_event_based_simulation(Input input, SimulationData data, unsigned long 
 	map(to:data.max_num_nucs)\
 	map(to:data.max_num_poles)\
 	map(to:data.max_num_windows)\
+        map(to:input)\
 	map(tofrom:offloaded_to_device)\
-  map(from:verification[:input.lookups])
+        map(from:verification[:input.lookups])\
+        defaultmap(none)
 	for( int i = 0; i < input.lookups; i++ )
 	{
 		// Set the initial seed value


### PR DESCRIPTION
The `Input` struct, `input`, is unnecessarily copied back to the host after execution of the target region.

This is minor and this fix has negligible performance improvement.

I additionally added a `defaultmap(none)` clause which enforces explicit data mapping at compile time, likely reducing the chance of similar oversights in the future.

Similar fix to https://github.com/ANL-CESAR/XSBench/pull/38.